### PR TITLE
SQOS initial OS support

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-SuperQuanamOS.v1.beta3
+SuperQuanamOS.v2.beta3

--- a/linux-files/grub/grub.cfg
+++ b/linux-files/grub/grub.cfg
@@ -1,7 +1,7 @@
 set default=0
 set timeout=5
 
-menuentry "QuantamOS" {
+menuentry "QuantamOS 2" {
     linux /boot/vmlinuz root=/dev/sr0 rw
     initrd /boot/initramfs.gz
 }

--- a/scripts/build-archlinux.sh
+++ b/scripts/build-archlinux.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# QuantamOS build.sh fix for Arch Linux
+# BE ELEVATED WITH SUDO
+if [ "$EUID" -ne 0 ]; then
+    echo "Please run this script as root or using sudo! or else"
+    exit 1
+fi
+# Ok back to the script
+sudo pacman -Syu --noconfirm
+sudo pacman -S --noconfirm base-devel ncurses bison flex openssl libelf grub xorriso ghc cabal-install libx11 libxft libxinerama
+
+wget https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.10.2.tar.xz
+tar -xvf linux-6.10.2.tar.xz
+cd linux-6.10.2
+make menuconfig
+make -j$(nproc)
+sudo make modules_install
+sudo make install
+
+if [ ! -f /boot/vmlinuz-6.10.2 ]; then
+    echo "Kernel image not found! Exiting."
+    exit 1
+fi
+
+cd ..
+mkdir -p quantam/rootfs/{bin,sbin,etc,proc,sys,usr/{bin,sbin}}
+
+wget https://busybox.net/downloads/busybox-1.33.1.tar.bz2
+tar -xvf busybox-1.33.1.tar.bz2
+cd busybox-1.33.1
+make defconfig
+make -j$(nproc)
+make install CONFIG_PREFIX=../quantam/rootfs
+
+echo "::sysinit:/etc/init.d/rcS" > ../quantam/rootfs/etc/inittab
+mkdir -p ../quantam/rootfs/etc/init.d
+echo "#!/bin/sh" > ../quantam/rootfs/etc/init.d/rcS
+echo "mount -t proc none /proc" >> ../quantam/rootfs/etc/init.d/rcS
+echo "mount -t sysfs none /sys" >> ../quantam/rootfs/etc/init.d/rcS
+echo "/sbin/mdev -s" >> ../quantam/rootfs/etc/init.d/rcS
+chmod +x ../quantam/rootfs/etc/init.d/rcS
+
+# Use xmonad
+sudo pacman -S --noconfirm xmonad
+cp /usr/bin/xmonad ../quantam/rootfs/usr/bin/
+# Uninstall xmonad
+sudo pacman -R --noconfirm xmonad
+mkdir -p ../quantam/rootfs/usr/share/X11/xorg.conf.d
+# Resolve #7
+cd ~/
+mkdir -p ~/quantam/rootfs/usr/local/bin
+curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sudo sh
+cd /usr/local/bin
+sudo mv distrobox distrobox-enter distrobox-generate-entry distrobox-list distrobox-upgrade distrobox-assemble distrobox-ephemeral  distrobox-host-exec distrobox-rm distrobox-create  distrobox-export  distrobox-init distrobox-stop ~/quantam/rootfs/usr/local/bin
+# Initial patch
+cd ~/quantam
+cd rootfs
+find . | cpio -o --format=newc | gzip > ../initramfs.gz
+# I Think that should fix it
+mkdir -p ~/iso/boot/grub
+cp /boot/vmlinuz-6.10.2 iso/boot/vmlinuz
+cp /boot/initramfs.gz iso/boot/initramfs.gz
+
+cat > iso/boot/grub/grub.cfg << EOF
+set default=0
+set timeout=5
+
+menuentry "QuantamOS" {
+    linux /boot/vmlinuz root=/dev/sr0
+    initrd /boot/initramfs.gz
+}
+EOF
+
+grub-mkrescue -o quantam.iso iso

--- a/scripts/build-fedora.sh
+++ b/scripts/build-fedora.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# QuantamOS build.sh fix for Fedora
+# BE ELEVATED WITH SUDO
+if [ "$EUID" -ne 0 ]; then
+    echo "Please run this script as root or using sudo! or else"
+    exit 1
+fi
+# Ok back to the script
+sudo dnf update -y
+sudo dnf install -y @development-tools ncurses-devel bison flex openssl-devel elfutils-libelf-devel grub2 xorriso ghc cabal-install libX11-devel libXft-devel libXinerama-devel
+
+wget https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.10.2.tar.xz
+tar -xvf linux-6.10.2.tar.xz
+cd linux-6.10.2
+make menuconfig
+make -j$(nproc)
+sudo make modules_install
+sudo make install
+
+if [ ! -f /boot/vmlinuz-6.10.2 ]; then
+    echo "Kernel image not found! Exiting."
+    exit 1
+fi
+
+cd ..
+mkdir -p quantam/rootfs/{bin,sbin,etc,proc,sys,usr/{bin,sbin}}
+
+wget https://busybox.net/downloads/busybox-1.33.1.tar.bz2
+tar -xvf busybox-1.33.1.tar.bz2
+cd busybox-1.33.1
+make defconfig
+make -j$(nproc)
+make install CONFIG_PREFIX=../quantam/rootfs
+
+echo "::sysinit:/etc/init.d/rcS" > ../quantam/rootfs/etc/inittab
+mkdir -p ../quantam/rootfs/etc/init.d
+echo "#!/bin/sh" > ../quantam/rootfs/etc/init.d/rcS
+echo "mount -t proc none /proc" >> ../quantam/rootfs/etc/init.d/rcS
+echo "mount -t sysfs none /sys" >> ../quantam/rootfs/etc/init.d/rcS
+echo "/sbin/mdev -s" >> ../quantam/rootfs/etc/init.d/rcS
+chmod +x ../quantam/rootfs/etc/init.d/rcS
+
+# Use xmonad
+sudo dnf install -y xmonad
+cp /usr/bin/xmonad ../quantam/rootfs/usr/bin/
+# Uninstall xmonad
+sudo dnf remove -y xmonad
+mkdir -p ../quantam/rootfs/usr/share/X11/xorg.conf.d
+# Resolve #7
+cd ~/
+mkdir -p ~/quantam/rootfs/usr/local/bin
+curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sudo sh
+cd /usr/local/bin
+sudo mv distrobox distrobox-enter distrobox-generate-entry distrobox-list distrobox-upgrade distrobox-assemble distrobox-ephemeral  distrobox-host-exec distrobox-rm distrobox-create  distrobox-export  distrobox-init distrobox-stop ~/quantam/rootfs/usr/local/bin
+# Initial patch
+cd ~/quantam
+cd rootfs
+find . | cpio -o --format=newc | gzip > ../initramfs.gz
+# I Think that should fix it
+mkdir -p ~/iso/boot/grub2
+cp /boot/vmlinuz-6.10.2 iso/boot/vmlinuz
+cp /boot/initramfs.gz iso/boot/initramfs.gz
+
+cat > iso/boot/grub2/grub.cfg << EOF
+set default=0
+set timeout=5
+
+menuentry "QuantamOS" {
+    linux /boot/vmlinuz root=/dev/sr0
+    initrd /boot/initramfs.gz
+}
+EOF
+
+grub2-mkrescue -o quantam.iso iso

--- a/scripts/build-gentoo.sh
+++ b/scripts/build-gentoo.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# QuantamOS build.sh fix for Gentoo
+# BE ELEVATED WITH SUDO
+if [ "$EUID" -ne 0 ]; then
+    echo "Please run this script as root or using sudo! or else"
+    exit 1
+fi
+# Ok back to the script
+emerge --sync
+emerge -avuDN @world
+emerge app-portage/gentoolkit
+emerge --ask sys-devel/gcc sys-devel/make sys-devel/binutils sys-kernel/linux-headers sys-apps/util-linux sys-kernel/gentoo-sources ncurses bison flex dev-libs/openssl sys-apps/kmod sys-boot/grub app-admin/xorriso ghc cabal-install x11-wm/xmonad x11-apps/xsetroot x11-apps/xprop
+
+wget https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.10.2.tar.xz
+tar -xvf linux-6.10.2.tar.xz
+cd linux-6.10.2
+make menuconfig
+make -j$(nproc)
+make modules_install
+make install
+
+if [ ! -f /boot/vmlinuz-6.10.2 ]; then
+    echo "Kernel image not found! Exiting."
+    exit 1
+fi
+
+cd ..
+mkdir -p quantam/rootfs/{bin,sbin,etc,proc,sys,usr/{bin,sbin}}
+
+wget https://busybox.net/downloads/busybox-1.33.1.tar.bz2
+tar -xvf busybox-1.33.1.tar.bz2
+cd busybox-1.33.1
+make defconfig
+make -j$(nproc)
+make install CONFIG_PREFIX=../quantam/rootfs
+
+echo "::sysinit:/etc/init.d/rcS" > ../quantam/rootfs/etc/inittab
+mkdir -p ../quantam/rootfs/etc/init.d
+echo "#!/bin/sh" > ../quantam/rootfs/etc/init.d/rcS
+echo "mount -t proc none /proc" >> ../quantam/rootfs/etc/init.d/rcS
+echo "mount -t sysfs none /sys" >> ../quantam/rootfs/etc/init.d/rcS
+echo "/sbin/mdev -s" >> ../quantam/rootfs/etc/init.d/rcS
+chmod +x ../quantam/rootfs/etc/init.d/rcS
+
+# Use xmonad
+cp /usr/bin/xmonad ../quantam/rootfs/usr/bin/
+# Uninstall xmonad
+emerge --deselect x11-wm/xmonad
+mkdir -p ../quantam/rootfs/usr/share/X11/xorg.conf.d
+# Resolve #7
+cd ~/
+mkdir -p ~/quantam/rootfs/usr/local/bin
+curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sudo sh
+cd /usr/local/bin
+sudo mv distrobox distrobox-enter distrobox-generate-entry distrobox-list distrobox-upgrade distrobox-assemble distrobox-ephemeral  distrobox-host-exec distrobox-rm distrobox-create  distrobox-export  distrobox-init distrobox-stop ~/quantam/rootfs/usr/local/bin
+# Initial patch
+cd ~/quantam
+cd rootfs
+find . | cpio -o --format=newc | gzip > ../initramfs.gz
+# I Think that should fix it
+mkdir -p ~/iso/boot/grub
+cp /boot/vmlinuz-6.10.2 iso/boot/vmlinuz
+cp /boot/initramfs.gz iso/boot/initramfs.gz
+
+cat > iso/boot/grub/grub.cfg << EOF
+set default=0
+set timeout=5
+
+menuentry "QuantamOS" {
+    linux /boot/vmlinuz root=/dev/sr0
+    initrd /boot/initramfs.gz
+}
+EOF
+
+grub-mkrescue -o quantam.iso iso


### PR DESCRIPTION
I Deleted those files initially since they were Outdated i recreated them for support for many OSes but not limited to 
```
* Arch Linux / Manjaro based Distros
* RHEL / Fedora / PlaytronOS based Distros
* Gentoo Linux based Distros
```